### PR TITLE
añade una sección para gitbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 | Generative Art in Go ([Gunroad](https://gumroad.com/l/generative-art-in-golang)) ([Leanpub](https://leanpub.com/generative-art-in-golang)) | Arte generativo y manejo de imánenes | Inglés |
 | [Black Hat Go: Go Programming for Hackers and Pentesters](https://www.amazon.com.mx/Black-Hat-Go-Programming-Pentesters/dp/1593278659) | Utiliza las particularidades de go para resolver problemas típicos de pentesting, brute force, etc... | Inglés |
 
+## Gitbooks
+
+| Título | Descripción | Idioma |
+|--------|-------------|--------|
+| [Go for JS Developers](www.pazams.com/Go-for-Javascript-Developers) | Este libro compara los lengujaes de programación Golang (o Go) y ECMAScript (o Javascript) | Inglés |
+| [Golang anti-frameworks](https://thewhitetulip.gitbook.io/bo) | Esta es un tutorial basado en un ejemplo fácil de entender, dirigido a aquellos que sabe un poco de Go y nada de webdev y quieren aprender a escribir un servidor web en Go | Inglés |
+| [Go Secure Coding Practices](https://checkmarx.gitbooks.io/go-scp) | Web Application Secure Coding Practices es una guía para cualquiera que esté usando el lenguaje de programación Go y tenga el objetivo de usarlo para desarrollo web | Inglés |
+| [Spaceship Go (stdlib journey)](https://blasrodri.github.io/spaceship-go-gh-pages) | Este es un conjuto de notas de mi viaje en una parte de la librería estándar de Go | Inglés |
+
 ## Cursos
 
 | Título | Descripción | Idioma |


### PR DESCRIPTION
Gitbooks sobre Golang:
- Go for JS Developers: pazams.com/Go-for-Javascript-Developers
- Golang anti frameworks: thewhitetulip.gitbook.io/bo
- Go Secure Coding Practices: checkmarx.gitbooks.io/go-scp
- Spaceship Go (stdlib journey): blasrodri.github.io/spaceship-go-gh-pages